### PR TITLE
Remove console.log

### DIFF
--- a/src/providers/android.js
+++ b/src/providers/android.js
@@ -10,7 +10,6 @@ export const getAndroidVersion = async(bundleId, country) => {
       }
     });
   } catch (e) {
-    console.log(e.response);
     if (e.response && e.response.status && e.response.status === 404) {
       throw new Error(
         `App with bundle ID "${bundleId}" not found in Google Play.`


### PR DESCRIPTION
Remove a console.log that is triggered if we get a 404 when looking for an updated version on Android.