### PR TITLE
Enhance android regex to get app version

### DIFF
--- a/src/providers/android.js
+++ b/src/providers/android.js
@@ -19,7 +19,7 @@ export const getAndroidVersion = async(bundleId, country) => {
     throw e;
   }
 
-  const version = res.data.match(/\[\[\[['"]((\d+\.)+\d+)['"]\]\],/)[1];
+  const version = res.data.match(/['"]((\d+\.)+\d+)['"](?<!['"]((0+\.)+0+)['"])/)[0];
 
   return {
     version: version || null,


### PR DESCRIPTION
It seems that the PlayStore changed the HTML structure and the regex is no more working.

That is my suggestion to fix this.