### PR TITLE
Fix get android version from html

### DIFF
--- a/src/providers/android.js
+++ b/src/providers/android.js
@@ -19,16 +19,7 @@ export const getAndroidVersion = async(bundleId, country) => {
     throw e;
   }
 
-  let getVersionFromHTML = (str) => {
-    const matches = str.match(/['"](\d+\.){2,}\d+['"]/gmi);
-    for (let match of matches) {
-      if (!/^['"](0+\.?)+['"]$/.test(match)) {
-        return match.replace(/['"]/g, '');
-      }
-    }
-    return null;
-  };
-  const version = getVersionFromHTML(res.data);
+  const version = res.data.match(/\[\[\[['"]((\d+\.)+\d+)['"]\]\],/)[1];
 
   return {
     version: version || null,

--- a/src/providers/android.js
+++ b/src/providers/android.js
@@ -19,7 +19,16 @@ export const getAndroidVersion = async(bundleId, country) => {
     throw e;
   }
 
-  const version = res.data.match(/['"]((\d+\.)+\d+)['"](?<!['"]((0+\.)+0+)['"])/)[0];
+  let getVersionFromHTML = (str) => {
+    const matches = str.match(/['"](\d+\.){2,}\d+['"]/gmi);
+    for (let match of matches) {
+      if (!/^['"](0+\.?)+['"]$/.test(match)) {
+        return match.replace(/['"]/g, '');
+      }
+    }
+    return null;
+  };
+  const version = getVersionFromHTML(res.data);
 
   return {
     version: version || null,


### PR DESCRIPTION
I have suggested an fix on #45 , but my project broken after updating the dependencies for this lib.
I think that the regex negative look behind is not implemented on react-native JS.

After some tests, I released that the HTML is not returning the correct app version and that my app was not in production track on PlayStore.
After released the app to production track, the old regex got the correct app version.

I am sorry for the issue and PR changing the code and case I've broken someone project.
This PR reverts the code to use the old regex and fix the library.